### PR TITLE
[fix] eslint 윈도우os 오류 수정 #30

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -88,6 +88,7 @@ module.exports = {
     'object-shorthand': 'error',
     'react/jsx-key': ['error', { checkFragmentShorthand: true }],
     'react/react-in-jsx-scope': 'off',
+    'prettier/prettier': ['error', { endOfLine: 'auto' }],
   },
   settings: {
     react: {

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
   semi: true,
   useTabs: false,
   printWidth: 100,
-  endOfLine: 'lf',
+  endOfLine: 'auto',
   arrowParens: 'always',
   jsxBracketSameLine: false,
   jsxSingleQuote: true,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
윈도우에서 줄바꿈 마다 에러 떠서 eslint 설정에 endOfLine 를 수정했습니다.
closes #30 

## 📋 작업 내용
 eslint - rules :  "prettier/prettier": ["error", { endOfLine: "auto" }]
prettier -  endOfLine: 'auto' 추가


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [x] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
