### PR TITLE
[refactor] input 컴포넌트 정렬 수정 (#57)

### DIFF
--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -26,36 +26,51 @@ const Input = ({
   type = 'text',
 }: InputProps) => (
   <div css={wrapperStyle}>
-    <Field>
+    <Field css={fieldStyle}>
       {label && <Label css={labelStyle}>{label}</Label>}
-      <InputFromUI
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        css={[inputStyle, readOnly && readOnlyStyle]}
-        placeholder={placeholder}
-        readOnly={readOnly}
-        type={type}
-      />
-      {isError && <Description css={errorStyle}>{errorMessage}</Description>}
+      <div css={inputWrapperStyle}>
+        <InputFromUI
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          css={[inputStyle, readOnly && readOnlyStyle]}
+          placeholder={placeholder}
+          readOnly={readOnly}
+          type={type}
+        />
+        {isError && <Description css={errorStyle}>{errorMessage}</Description>}
+      </div>
       {readOnly && <div css={readOnlyStyle} />}
     </Field>
   </div>
 );
 
 const wrapperStyle = css`
-  display: inline-block;
+  display: block;
   margin-bottom: 1rem;
+  width: 100%;
+`;
+
+const fieldStyle = css`
+  display: flex;
+`;
+
+const inputWrapperStyle = css`
+  display: flex;
+  flex-direction: column;
   width: 100%;
 `;
 
 const labelStyle = css`
   display: flex;
-  margin-bottom: 0.5rem;
+  align-items: center;
+  justify-content: flex-start;
+  width: 8rem;
   font-size: ${theme.fontSizes.normal};
   color: ${theme.colors.black};
 `;
 
 const inputStyle = css`
+  flex-grow: 1;
   width: 100%;
   padding: 0.5rem 1rem;
   border: 1px solid ${theme.colors.lightGray};
@@ -71,6 +86,7 @@ const inputStyle = css`
 `;
 
 const errorStyle = css`
+  display: block;
   margin-top: 0.5rem;
   font-size: ${theme.fontSizes.normal};
   color: ${theme.colors.alertRed};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

인풋 정렬 수정했습니다. 
closes #57

## 📋 작업 내용
라벨 - 왼쪽, 
인풋 - 오른쪽, 
에러메세지 - 인풋의 하단,
라벨이 없을 경우 - 인풋 전체
로 CSS 수정했습니다.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [x] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)
![image](https://github.com/user-attachments/assets/d4aca9f6-5213-49f5-baf6-f06a7663bb34)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
