### PR TITLE
[feat] 오늘의 일정 컴포넌트 구현

### DIFF
--- a/src/components/daySchedule/DaySchedule.tsx
+++ b/src/components/daySchedule/DaySchedule.tsx
@@ -1,0 +1,209 @@
+import { css } from '@emotion/react';
+import dayjs from 'dayjs';
+import 'dayjs/locale/ko';
+import { HiChevronRight } from 'react-icons/hi2';
+
+import theme from '@/styles/theme';
+import { ScheduleModel } from '@/types/schedule';
+dayjs.locale('ko');
+
+// ScheduleList 컴포넌트의 props 타입 정의
+interface ScheduleListProps {
+  date: string;
+  schedules: ScheduleModel[];
+}
+interface ScheduleItemProps {
+  schedule: ScheduleModel;
+  date: string;
+  key: string;
+}
+// 유틸리티 함수
+// date: 캘린더 컴포넌트의 activeDate(default: 오늘 날짜)
+const formatDate = (date: string) => dayjs(date).format('M월 D일 (ddd)');
+
+// 시간 포맷팅
+const formatTime = (time: string) => {
+  const [hour, minute] = time.split(':');
+  return dayjs().hour(parseInt(hour)).minute(parseInt(minute)).format('A hh:mm');
+};
+
+// DateType 정의
+type DateType = 'same' | 'start' | 'end' | 'between';
+
+// 날짜 타입 결정 함수
+const getDateType = (currentDate: string, startDate: string, endDate: string): DateType => {
+  const current = dayjs(currentDate);
+  const start = dayjs(startDate);
+  const end = dayjs(endDate);
+
+  if (start.isSame(end, 'day')) return 'same';
+  if (current.isSame(start, 'day')) return 'start';
+  if (current.isSame(end, 'day')) return 'end';
+  if (current.isAfter(start) && current.isBefore(end)) return 'between';
+  return 'between'; // 기본값
+};
+
+// 시간 범위 문자열 생성 함수
+const getTimeRangeString = (dateType: DateType, startTime: string, endTime: string): string => {
+  switch (dateType) {
+    case 'same':
+      return `${formatTime(startTime)} - ${formatTime(endTime)}`;
+    case 'start':
+      return `${formatTime(startTime)} - 오후 11:59`;
+    case 'end':
+      return `오전 00:00 - ${formatTime(endTime)}`;
+    case 'between':
+      return '하루종일';
+  }
+};
+
+// 메인 함수: ScheduleItem에 하루종일 또는 오후/오전시간 알려주는 함수
+const formatTimeRange = (date: string, schedule: ScheduleModel) => {
+  const dateType = getDateType(date, schedule.startDate, schedule.endDate);
+  return getTimeRangeString(dateType, schedule.startTime, schedule.endTime);
+};
+
+// 일정 컴포넌트
+const DaySchedule = ({ date, schedules }: ScheduleListProps) => (
+  <div css={dayScheduleWrap}>
+    <h2>{formatDate(date)}</h2>
+    <ScheduleList date={date} schedules={schedules} />
+  </div>
+);
+
+// isDaySchedule 함수를 dayjs를 사용하여 구현
+const isDaySchedule = (date: string, schedule: ScheduleModel): boolean => {
+  const checkDate = dayjs(date);
+  return (
+    checkDate.isSame(schedule.startDate) ||
+    checkDate.isSame(schedule.endDate) ||
+    (checkDate.isAfter(schedule.startDate) && checkDate.isBefore(schedule.endDate))
+  );
+};
+
+// map 함수를 별도의 함수로 분리
+const renderScheduleItems = (filteredSchedules: ScheduleModel[], date: string) =>
+  filteredSchedules.map((item, idx: number) => (
+    <ScheduleItem schedule={item} date={date} key={`schedule-${item.id || idx}`} />
+  ));
+// 일정 리스트
+const ScheduleList = ({ date, schedules }: ScheduleListProps) => {
+  const filteredSchedules = schedules.filter((schedule) => isDaySchedule(date, schedule));
+
+  return (
+    <div css={scheduleListStyle}>
+      <h3>
+        일정 <span>{filteredSchedules.length}</span>
+      </h3>
+      <ul css={scheduleItemsStyle}>
+        {filteredSchedules.length === 0 ? (
+          <li css={emptyListStyle}>일정이 없습니다.</li>
+        ) : (
+          renderScheduleItems(filteredSchedules, date)
+        )}
+      </ul>
+    </div>
+  );
+};
+
+// 일정 아이템
+const ScheduleItem = ({ schedule, date }: ScheduleItemProps) => (
+  <li css={scheduleItemStyle(schedule)}>
+    <h3>
+      {schedule.subject}
+      <HiChevronRight />
+    </h3>
+    <p>{formatTimeRange(date, schedule)}</p>
+  </li>
+);
+
+// 스타일
+const dayScheduleWrap = css`
+  margin: 1rem 0 100px;
+  padding: 1.5rem 1rem;
+  background-color: ${theme.colors.white};
+  h2 {
+    color: ${theme.colors.darkestGray};
+    font-size: ${theme.fontSizes.normal};
+    margin-bottom: 1rem;
+    font-weight: 600;
+  }
+  span {
+    color: ${theme.colors.primary};
+  }
+`;
+const scheduleListStyle = css`
+  position: relative;
+  display: flex;
+
+  justify-content: flex-start;
+  align-items: center;
+  font-size: ${theme.fontSizes.normal};
+  width: 100%;
+  gap: 50px;
+  & > h3 {
+    width: 60px;
+    display: flex;
+    flex-direction: row;
+    color: ${theme.colors.darkGray};
+    align-self: flex-start;
+    font-weight: 600;
+  }
+  span {
+    display: block;
+    margin-left: 4px;
+  }
+`;
+const scheduleItemsStyle = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  width: inherit;
+  gap: 12px;
+  cursor: pointer;
+`;
+const emptyListStyle = css`
+  width: inherit;
+  height: 35px;
+  text-indent: 12px;
+  line-height: 1.2rem;
+  color: ${theme.colors.darkGray};
+  font-size: ${theme.fontSizes.normal};
+  font-weight: 600;
+`;
+const scheduleItemStyle = (schedule: ScheduleModel) => css`
+  position: relative;
+  min-width: 200px;
+  height: 35px;
+  background-color: ${theme.colors.white};
+  color: ${theme.colors.darkestGray};
+  padding-left: 12px;
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 4px;
+    height: 35px;
+    background-color: ${schedule.color};
+  }
+  h3 {
+    color: ${theme.colors.darkestGray};
+    font-weight: 600;
+    line-height: 1.2rem;
+    display: flex;
+    align-items: center;
+  }
+  h3 > svg {
+    width: 12px;
+    stroke-width: 1.2;
+    color: ${theme.colors.darkGray};
+  }
+  p {
+    line-height: 1rem;
+    color: ${theme.colors.darkGray};
+    font-size: ${theme.fontSizes.small};
+  }
+`;
+export default DaySchedule;

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { css } from '@emotion/react';
 
 import CalendarComponent from '@/components/Calendar/Calendar';
+import DaySchedule from '@/components/daySchedule/DaySchedule';
 import useFetchSchedule from '@/hooks/useFetchSchedule';
 import theme from '@/styles/theme';
 
@@ -15,6 +16,9 @@ const SchedulePage = () => {
       <h1 className='page-title'>일정</h1>
       <div className='wrapper' css={calendarWrapperStyle}>
         <CalendarComponent events={events} activeDate={activeDate} setActiveDate={setActiveDate} />
+      </div>
+      <div>
+        <DaySchedule date={activeDate.toISOString()} schedules={schedule} />
       </div>
     </>
   );


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
closes #54 
<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 달력 페이지에 오늘의 일정을 보여주는 컴포넌트 추가
- 달력에서 받아온 특정 날짜(기본값:오늘날짜)를 받아 보여주고, 해당 날짜의 일정을 보여줌
- 해당 날짜의 일정의 총 갯수를 보여줌
    - 일정이 없을 경우 "일정이 없습니다" 라는 문구를 보여줌
    - 일정이 있을 경우 각 일정의 제목과 시간을 보여줌
- 일정에서 시간을 보여줄 때,
    - 시작일과 종료일이 같을 경우 시작시간 - 종료시간으로 표시
    - 시작일과 종료일이 다를 경우
        - 시작일이 현재선택된 날짜일 경우: 시작시간 - 23:59 로 표시
        - 종료일이 현재선택된 날짜일 경우: 00:00 - 종료시간으로 표시
    - 시작일과 종료일이 현재선택된 날짜 사이에 있을 경우(그 외 나머지 경우): 하루종일로 표시

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img src="https://github.com/user-attachments/assets/45f45ab7-0d69-4e44-a6e4-e00939bb9826"  width="250px"/>
<img src="https://github.com/user-attachments/assets/c43e68e3-f1d9-44a9-b206-b47163c42ae6"  width="250px"/>
<img src="https://github.com/user-attachments/assets/9c9d4170-d7b9-4845-b974-7c45a880b15b"  width="250px"/>

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
