### PR TITLE
[fix] 일정상세 페이지에서 헤더 부분 디자인이 찌그러지는 것 수정

### DIFF
--- a/src/components/common/buttons/IconTextButton.tsx
+++ b/src/components/common/buttons/IconTextButton.tsx
@@ -43,6 +43,7 @@ const iconButtonStyle = css`
   font-weight: 500;
   background-color: ${theme.colors.white};
   transition: all 300ms ease;
+  flex-shrink: 0;
 
   &.left {
     flex-direction: row-reverse;

--- a/src/pages/DailyScheduleDetail.tsx
+++ b/src/pages/DailyScheduleDetail.tsx
@@ -112,6 +112,7 @@ const titleStyle = css`
   h1 {
     margin-left: 0.5rem;
     font-size: ${theme.fontSizes.xlarge};
+    flex-shrink: 1;
   }
 `;
 const circleStyle = (schedule: ScheduleModel) => css`
@@ -119,6 +120,7 @@ const circleStyle = (schedule: ScheduleModel) => css`
   height: 20px;
   border-radius: 50%;
   background-color: ${schedule.color};
+  flex-shrink: 0;
 `;
 const contentStyle = css`
   


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)
수정 전 -> 후
- 일정 제목 글자크기가 18px(피그마 기준)인데, 제목이 길어져서 2줄이 되면 어떻게 해야할지 고민중..
<img width="300" alt="스크린샷 2024-08-05 오전 12 07 45" src="https://github.com/user-attachments/assets/d033c206-83eb-4f03-a858-2f77cf655bee">
<img width="300" alt="스크린샷 2024-08-05 오전 12 23 20" src="https://github.com/user-attachments/assets/970b2829-5c73-4e2b-b06c-8d0a2e947ccc">



## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
