### PR TITLE
[feat] 일정 삭제하기

### DIFF
--- a/src/pages/DailyScheduleDetail.tsx
+++ b/src/pages/DailyScheduleDetail.tsx
@@ -8,6 +8,8 @@ import Button from '@/components/common/buttons/Button';
 import IconTextButton from '@/components/common/buttons/IconTextButton';
 import Modal from '@/components/common/Modal';
 import Header from '@/components/layout/Header';
+import { useAppDispatch } from '@/store/hooks';
+import { deleteSchedule } from '@/store/reducer/scheduleSlice';
 import theme from '@/styles/theme';
 import { ScheduleModel } from '@/types/schedule';
 import { formatTime, formatOnlyDate } from '@/utils/dailySchedule';
@@ -15,6 +17,7 @@ import { formatTime, formatOnlyDate } from '@/utils/dailySchedule';
 const DailyScheduleDetail = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
   const schedule: ScheduleModel = location.state?.schedule;
   const [text, setText] = useState(schedule.content);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -25,15 +28,20 @@ const DailyScheduleDetail = () => {
   };
 
   // 일정삭제 모달에서 일정 취소하기 버튼 클릭
-  const handleConfirmDelete = () => {
-    // TODO: 일정 삭제 API 호출
-    // 파이어스토어에 일정 삭제하는 코드 필요
+  const handleConfirmDelete = async (scheduleId: string) => {
+    try {
+      // TODO: 일정 삭제 API 호출
+      await dispatch(deleteSchedule(scheduleId)).unwrap(); // unwrap()은 비동기 함수의 반환값(Promise)을 반환
+      setIsModalOpen(false);
 
-    setIsModalOpen(false);
+      // navigate해주기 전에 삭제되었다고 토스트ui 띄우기 코드 필요
 
-    // navigate해주기 전에 삭제되었다고 토스트ui 띄우기 코드 필요
-    navigate('/schedule');
+      navigate('/schedule');
+    } catch (error) {
+      console.error(error);
+    }
   };
+
   // 일정삭제 모달에서 취소 버튼 클릭
   const handleCancelDelete = () => {
     setIsModalOpen(false);
@@ -81,11 +89,11 @@ const DailyScheduleDetail = () => {
         <Modal
           isOpen={isModalOpen}
           onClose={handleCancelDelete}
-          onConfirm={handleConfirmDelete}
-          styleType='secondary'
+          onConfirm={() => handleConfirmDelete(schedule.id)}
           title='일정을 삭제하시겠습니까?'
-          confirmText='일정 삭제하기'
-          cancelText='취소하기'
+          confirmText='삭제하기'
+          cancelText='취소'
+          styleType='secondary'
         />
       )}
     </div>

--- a/src/pages/DailyScheduleDetail.tsx
+++ b/src/pages/DailyScheduleDetail.tsx
@@ -91,7 +91,7 @@ const DailyScheduleDetail = () => {
           onClose={handleCancelDelete}
           onConfirm={() => handleConfirmDelete(schedule.id)}
           title='일정을 삭제하시겠습니까?'
-          confirmText='삭제하기'
+          confirmText='일정 삭제하기'
           cancelText='취소'
           styleType='secondary'
         />

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -5,8 +5,8 @@ import { HiPlus } from 'react-icons/hi2';
 import { useNavigate } from 'react-router-dom';
 
 import CalendarComponent from '@/components/calendar/Calendar';
-import { PATH } from '@/constants/path';
 import DailySchedule from '@/components/dailySchedule/DailySchedule';
+import { PATH } from '@/constants/path';
 import useFetchSchedule from '@/hooks/useFetchSchedule';
 import theme from '@/styles/theme';
 

--- a/src/store/reducer/scheduleSlice.ts
+++ b/src/store/reducer/scheduleSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
-import { collection, getDocs, query } from 'firebase/firestore';
+import { collection, deleteDoc, doc, getDocs, query } from 'firebase/firestore';
 
 import { db } from '@/api';
 import { status } from '@/types/api';
@@ -33,6 +33,19 @@ export const scheduleSlice = createSlice({
       .addCase(fetchSchedule.rejected, (state, action) => {
         state.status = 'failed';
         state.error = action.error.message || '일정을 가져올 수 없습니다.';
+      })
+      .addCase(deleteSchedule.pending, (state) => {
+        state.status = 'loading';
+      })
+      .addCase(deleteSchedule.fulfilled, (state, action) => {
+        state.status = 'succeeded';
+        state.schedule = state.schedule = state.schedule.filter(
+          (item) => item.id !== action.payload
+        );
+      })
+      .addCase(deleteSchedule.rejected, (state, action) => {
+        state.status = 'failed';
+        state.error = action.error.message || '일정을 삭제할 수 없습니다.';
       });
   },
 });
@@ -55,5 +68,17 @@ export const fetchSchedule = createAsyncThunk('schedule/fetchSchedule', async ()
     throw new Error('일정을 가져올 수 없습니다.');
   }
 });
+
+export const deleteSchedule = createAsyncThunk(
+  'schedule/deleteSchedule',
+  async (scheduleId: string, { rejectWithValue }) => {
+    try {
+      await deleteDoc(doc(db, 'Schedule', scheduleId));
+      return scheduleId;
+    } catch (error) {
+      return rejectWithValue('일정을 삭제할 수 없습니다.');
+    }
+  }
+);
 
 export default scheduleSlice.reducer;

--- a/src/types/calendar.d.ts
+++ b/src/types/calendar.d.ts
@@ -1,7 +1,7 @@
 type NavigateType = 'PREV' | 'NEXT' | 'TODAY' | 'DATE';
 
 export interface EventModel {
-  id?: number;
+  id?: string;
   start: Date;
   end: Date;
   title: string;

--- a/src/types/schedule.d.ts
+++ b/src/types/schedule.d.ts
@@ -11,6 +11,6 @@ export interface ScheduleFormDataModel {
 }
 
 export interface ScheduleModel extends ScheduleFormDataModel {
-  id: number;
+  id: string;
   userNo: number;
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- Schedule의 id 타입을 number => **string**으로 변경
- Firestore 컬렉션 데이터 모두 변경(8월 데이터), 테스트 가능)
    - calendar.d.ts와 schedule.d.ts 변경
- scheduleSlice.ts에 삭제api 호출 정의 및 addCase 추가
- DailyScheduleDetail.tsx
    - 일정삭제 모달창에서 삭제하기 버튼을 누르면 삭제 후 /schedule로 이동

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="350px" src="https://github.com/user-attachments/assets/1dc7f1e1-f667-4a2d-ac1b-668a8774b81d" />




## 📄 기타

- 캘린더에서 2개이상 일정인데도 불구하고 1개의 일정만 나오는 버그 발견
- 삭제 후 schedule 페이지로 이동할 때, 삭제한 일정의 월(month)이 보이는 기능구현 필요
