### PR TITLE
[fix] 오늘의 일정 중 페이지 로딩 후 1개의 일정만 보이는 에러 해결

### DIFF
--- a/src/pages/DailyScheduleDetail.tsx
+++ b/src/pages/DailyScheduleDetail.tsx
@@ -8,6 +8,8 @@ import Button from '@/components/common/buttons/Button';
 import IconTextButton from '@/components/common/buttons/IconTextButton';
 import Modal from '@/components/common/Modal';
 import Header from '@/components/layout/Header';
+import { useAppDispatch } from '@/store/hooks';
+import { deleteSchedule } from '@/store/reducer/scheduleSlice';
 import theme from '@/styles/theme';
 import { ScheduleModel } from '@/types/schedule';
 import { formatTime, formatOnlyDate } from '@/utils/dailySchedule';
@@ -15,6 +17,7 @@ import { formatTime, formatOnlyDate } from '@/utils/dailySchedule';
 const DailyScheduleDetail = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
   const schedule: ScheduleModel = location.state?.schedule;
   const [text, setText] = useState(schedule.content);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -25,15 +28,20 @@ const DailyScheduleDetail = () => {
   };
 
   // 일정삭제 모달에서 일정 취소하기 버튼 클릭
-  const handleConfirmDelete = () => {
-    // TODO: 일정 삭제 API 호출
-    // 파이어스토어에 일정 삭제하는 코드 필요
+  const handleConfirmDelete = async (scheduleId: string) => {
+    try {
+      // TODO: 일정 삭제 API 호출
+      await dispatch(deleteSchedule(scheduleId)).unwrap(); // unwrap()은 비동기 함수의 반환값(Promise)을 반환
+      setIsModalOpen(false);
 
-    setIsModalOpen(false);
+      // navigate해주기 전에 삭제되었다고 토스트ui 띄우기 코드 필요
 
-    // navigate해주기 전에 삭제되었다고 토스트ui 띄우기 코드 필요
-    navigate('/schedule');
+      navigate('/schedule');
+    } catch (error) {
+      console.error(error);
+    }
   };
+
   // 일정삭제 모달에서 취소 버튼 클릭
   const handleCancelDelete = () => {
     setIsModalOpen(false);
@@ -81,11 +89,11 @@ const DailyScheduleDetail = () => {
         <Modal
           isOpen={isModalOpen}
           onClose={handleCancelDelete}
-          onConfirm={handleConfirmDelete}
-          styleType='secondary'
+          onConfirm={() => handleConfirmDelete(schedule.id)}
           title='일정을 삭제하시겠습니까?'
-          confirmText='일정 삭제하기'
-          cancelText='취소하기'
+          confirmText='삭제하기'
+          cancelText='취소'
+          styleType='secondary'
         />
       )}
     </div>

--- a/src/pages/DailyScheduleDetail.tsx
+++ b/src/pages/DailyScheduleDetail.tsx
@@ -91,7 +91,7 @@ const DailyScheduleDetail = () => {
           onClose={handleCancelDelete}
           onConfirm={() => handleConfirmDelete(schedule.id)}
           title='일정을 삭제하시겠습니까?'
-          confirmText='삭제하기'
+          confirmText='일정 삭제하기'
           cancelText='취소'
           styleType='secondary'
         />

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -5,8 +5,8 @@ import { HiPlus } from 'react-icons/hi2';
 import { useNavigate } from 'react-router-dom';
 
 import CalendarComponent from '@/components/calendar/Calendar';
-import { PATH } from '@/constants/path';
 import DailySchedule from '@/components/dailySchedule/DailySchedule';
+import { PATH } from '@/constants/path';
 import useFetchSchedule from '@/hooks/useFetchSchedule';
 import theme from '@/styles/theme';
 

--- a/src/store/reducer/scheduleSlice.ts
+++ b/src/store/reducer/scheduleSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
-import { collection, getDocs, query } from 'firebase/firestore';
+import { collection, deleteDoc, doc, getDocs, query } from 'firebase/firestore';
 
 import { db } from '@/api';
 import { status } from '@/types/api';
@@ -33,6 +33,19 @@ export const scheduleSlice = createSlice({
       .addCase(fetchSchedule.rejected, (state, action) => {
         state.status = 'failed';
         state.error = action.error.message || '일정을 가져올 수 없습니다.';
+      })
+      .addCase(deleteSchedule.pending, (state) => {
+        state.status = 'loading';
+      })
+      .addCase(deleteSchedule.fulfilled, (state, action) => {
+        state.status = 'succeeded';
+        state.schedule = state.schedule = state.schedule.filter(
+          (item) => item.id !== action.payload
+        );
+      })
+      .addCase(deleteSchedule.rejected, (state, action) => {
+        state.status = 'failed';
+        state.error = action.error.message || '일정을 삭제할 수 없습니다.';
       });
   },
 });
@@ -55,5 +68,17 @@ export const fetchSchedule = createAsyncThunk('schedule/fetchSchedule', async ()
     throw new Error('일정을 가져올 수 없습니다.');
   }
 });
+
+export const deleteSchedule = createAsyncThunk(
+  'schedule/deleteSchedule',
+  async (scheduleId: string, { rejectWithValue }) => {
+    try {
+      await deleteDoc(doc(db, 'Schedule', scheduleId));
+      return scheduleId;
+    } catch (error) {
+      return rejectWithValue('일정을 삭제할 수 없습니다.');
+    }
+  }
+);
 
 export default scheduleSlice.reducer;

--- a/src/types/calendar.d.ts
+++ b/src/types/calendar.d.ts
@@ -1,7 +1,7 @@
 type NavigateType = 'PREV' | 'NEXT' | 'TODAY' | 'DATE';
 
 export interface EventModel {
-  id?: string;
+  id?: number;
   start: Date;
   end: Date;
   title: string;

--- a/src/types/calendar.d.ts
+++ b/src/types/calendar.d.ts
@@ -1,7 +1,7 @@
 type NavigateType = 'PREV' | 'NEXT' | 'TODAY' | 'DATE';
 
 export interface EventModel {
-  id?: number;
+  id?: string;
   start: Date;
   end: Date;
   title: string;

--- a/src/types/schedule.d.ts
+++ b/src/types/schedule.d.ts
@@ -11,6 +11,6 @@ export interface ScheduleFormDataModel {
 }
 
 export interface ScheduleModel extends ScheduleFormDataModel {
-  id: string;
-  userNo: number;
+  id: number;
+  userNo: string;
 }

--- a/src/types/schedule.d.ts
+++ b/src/types/schedule.d.ts
@@ -11,6 +11,6 @@ export interface ScheduleFormDataModel {
 }
 
 export interface ScheduleModel extends ScheduleFormDataModel {
-  id: number;
+  id: string;
   userNo: number;
 }

--- a/src/utils/dailySchedule.ts
+++ b/src/utils/dailySchedule.ts
@@ -64,17 +64,13 @@ const isDailySchedule = (date: string, schedule: ScheduleModel): boolean => {
   const startDate = dayjs(schedule.startDate).startOf('day');
   const endDate = dayjs(schedule.endDate).startOf('day');
 
-  // 시작 날짜와 종료 날짜가 같은 경우 (당일 일정)
-  if (startDate.isSame(endDate, 'day')) {
-    return checkDate.isSame(startDate, 'day');
+  // 체크 날짜가 시작일 또는 종료일과 같은 경우(당일 일정인 경우)
+  if (checkDate.isSame(startDate, 'day') || checkDate.isSame(endDate, 'day')) {
+    return true;
   }
 
-  // 여러 날에 걸친 일정의 경우
-  return (
-    checkDate.isSame(startDate, 'day') ||
-    checkDate.isSame(endDate, 'day') ||
-    (checkDate.isAfter(startDate) && checkDate.isBefore(endDate))
-  );
+  // 여러 날에 걸친 일정의 경우, 시작일과 종료일 사이에 있는지 여부를 판단
+  return checkDate.isAfter(startDate) && checkDate.isBefore(endDate);
 };
 
 export { formatDate, formatOnlyDate, formatTime, formatTimeRange, isDailySchedule };

--- a/src/utils/dailySchedule.ts
+++ b/src/utils/dailySchedule.ts
@@ -54,13 +54,26 @@ const formatTimeRange = (date: string, schedule: ScheduleModel) => {
   return getTimeRangeString(dateType, schedule.startTime, schedule.endTime);
 };
 
-// isDailySchedule 함수를 dayjs를 사용하여 구현
+// 1. 모든 날짜를 일(day) 단위로 비교 => 시간차이로 인한 오류를 방지하기 위해 startOf('day') 사용
+// dayjs().startOf('day') => 오늘 날짜 00:00:00
+// dayjs().endOf('day') => 오늘 날짜 23:59:59
+// 2. 당일 일정(시작날짜와 종료날짜가 같은 경우)인지 여부를 판단하는 함수
+// 3. 여러 날에 걸친 일정의 경우, 시작일, 종료일, 그 사이 날짜에 대한 판단을 추가
 const isDailySchedule = (date: string, schedule: ScheduleModel): boolean => {
-  const checkDate = dayjs(date);
+  const checkDate = dayjs(date).startOf('day');
+  const startDate = dayjs(schedule.startDate).startOf('day');
+  const endDate = dayjs(schedule.endDate).startOf('day');
+
+  // 시작 날짜와 종료 날짜가 같은 경우 (당일 일정)
+  if (startDate.isSame(endDate, 'day')) {
+    return checkDate.isSame(startDate, 'day');
+  }
+
+  // 여러 날에 걸친 일정의 경우
   return (
-    checkDate.isSame(schedule.startDate) ||
-    checkDate.isSame(schedule.endDate) ||
-    (checkDate.isAfter(schedule.startDate) && checkDate.isBefore(schedule.endDate))
+    checkDate.isSame(startDate, 'day') ||
+    checkDate.isSame(endDate, 'day') ||
+    (checkDate.isAfter(startDate) && checkDate.isBefore(endDate))
   );
 };
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
closes #129 
<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

1. 모든 날짜를 일(day) 단위로 비교 => 시간차이로 인한 오류를 방지하기 위해 `startOf('day')` 사용
- `dayjs().startOf('day')` => 오늘 날짜 00:00:00
- `dayjs().endOf('day')` => 오늘 날짜 23:59:59
2. 당일 일정(시작날짜와 종료날짜가 같은 경우)인지 여부를 판단하는 함수
3. 그렇지 않다면, 여러 날에 걸친 일정의 경우, 시작일과 종료일 사이에 있는지 판단

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
