### PR TITLE
[feat] 일정 수정 기능 추가

### DIFF
--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -1,4 +1,4 @@
-import { addDoc, collection } from 'firebase/firestore';
+import { addDoc, collection, doc, updateDoc } from 'firebase/firestore';
 
 import { db } from '@/api';
 import { getCollectionId } from '@/api/common';
@@ -10,8 +10,6 @@ import { getUID } from '@/utils/auth';
 export const addSchedule = async (
   data: ScheduleFormDataModel
 ): Promise<ApiResponse<ScheduleResponseType>> => {
-  console.log(data);
-
   const scheduleData: ScheduleModel = {
     ...data,
     id: await getCollectionId({
@@ -22,6 +20,17 @@ export const addSchedule = async (
   };
 
   await addDoc(collection(db, FIRESTORE_COLLECTION.schedule), scheduleData);
+
+  return { status: 'succeeded', response: true };
+};
+
+export const editSchedule = async (
+  newData: ScheduleModel
+): Promise<ApiResponse<ScheduleResponseType>> => {
+  const scheduleRef = doc(db, FIRESTORE_COLLECTION.schedule, newData.docId as string);
+  await updateDoc(scheduleRef, {
+    ...newData,
+  });
 
   return { status: 'succeeded', response: true };
 };

--- a/src/components/scheduleForm/ScheduleForm.tsx
+++ b/src/components/scheduleForm/ScheduleForm.tsx
@@ -14,7 +14,7 @@ import theme from '@/styles/theme';
 import { ScheduleFormDataModel } from '@/types/schedule';
 import { convertDateWithFormat } from '@/utils/dailySchedule';
 
-const ALARM_OPTIONS = {
+export const ALARM_OPTIONS = {
   NONE: '없음',
   TEN_MINUTES: '10분 전',
   THIRTY_MINUTES: '30분 전',
@@ -36,6 +36,9 @@ interface ScheduleFormProps {
   initEndDate?: Date;
   initStartTime?: string;
   initEndTime?: string;
+  initTitleValue?: string;
+  initContentValue?: string;
+  submitButtonText?: string;
   onSubmit: (data: ScheduleFormDataModel) => void;
 }
 
@@ -47,11 +50,14 @@ const ScheduleForm = ({
   initEndDate = new Date(),
   initStartTime = dayjs().minute(0).format('HH:mm'),
   initEndTime = dayjs().minute(0).format('HH:mm'),
+  initTitleValue = '',
+  initContentValue = '',
+  submitButtonText = '일정 추가하기',
   onSubmit,
 }: ScheduleFormProps) => {
   const formRef = useRef<HTMLFormElement>(null);
   const titleInputRef = useRef<HTMLInputElement>(null);
-  const [titleValue, setTitleValue] = useState('');
+  const [titleValue, setTitleValue] = useState(initTitleValue);
   const [enableAllDay, setEnableAllDay] = useState(initEnableAllDay);
   const [selectedAlarmOption, setSelectedAlarmOption] = useState(initSelectedAlarmOption);
   const [selectedColor, setSelectedColor] = useState(initSelectedColor);
@@ -61,9 +67,17 @@ const ScheduleForm = ({
   const [startTime, setStartTime] = useState(initStartTime);
   const [endTime, setEndTime] = useState(initEndTime);
 
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
   useEffect(() => {
     titleInputRef.current?.focus();
   }, []);
+
+  useEffect(() => {
+    if (textAreaRef.current && initContentValue) {
+      textAreaRef.current.value = initContentValue;
+    }
+  }, [initContentValue]);
 
   const onTitle = (event: ChangeEvent<HTMLInputElement>) => setTitleValue(event.target.value);
   const onSubmitForm = (event: FormEvent<HTMLFormElement>) => {
@@ -128,10 +142,15 @@ const ScheduleForm = ({
           <span>색상</span>
           <ColorPicker selected={selectedColor} setSelected={setSelectedColor} />
         </div>
-        <textarea name='content' css={textareaStyle} placeholder='메모를 입력하세요.' />
+        <textarea
+          name='content'
+          css={textareaStyle}
+          placeholder='메모를 입력하세요.'
+          ref={textAreaRef}
+        />
         <div css={buttonContainerStyle}>
           <Button type='submit' styleType={`${!titleValue.trim() ? 'disabled' : 'primary'}`}>
-            일정 추가하기
+            {submitButtonText}
           </Button>
         </div>
       </form>

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -3,7 +3,7 @@ export const PATH = {
   SCHEDULE: '/schedule',
   SCHEDULE_DETAIL: 'detail/:id',
   SCHEDULE_ADD: 'add',
-  SCHEDULE_EDIT: 'edit',
+  SCHEDULE_EDIT: 'edit/:id',
   SALARY: '/salary',
   SALARY_DETAIL: 'detail/:year/:month',
   SALARY_CORRECTION_HISTORY: 'correction',

--- a/src/pages/ScheduleEdit.tsx
+++ b/src/pages/ScheduleEdit.tsx
@@ -1,16 +1,69 @@
+import { useNavigate, useParams } from 'react-router-dom';
+
 import Header from '@/components/layout/Header';
-import ScheduleForm from '@/components/scheduleForm/ScheduleForm';
+import { ColorsType } from '@/components/scheduleForm/ColorPicker';
+import ScheduleForm, { ALARM_OPTIONS } from '@/components/scheduleForm/ScheduleForm';
+import { PATH } from '@/constants/path';
+import useFetchSchedule from '@/hooks/useFetchSchedule';
+import useToast from '@/hooks/useToast';
+import { useAppDispatch } from '@/store/hooks';
+import { fetchEditSchedule } from '@/store/reducer/scheduleSlice';
 import { ScheduleFormDataModel } from '@/types/schedule';
+import { getScheduleData } from '@/utils/schedule';
 
 const ScheduleEditPage = () => {
-  const onEdit = (data: ScheduleFormDataModel) => {
-    console.log('edit', data);
+  const { schedule } = useFetchSchedule();
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const { toastTrigger } = useToast();
+
+  if (!schedule.length) return;
+
+  const scheduleData = getScheduleData(schedule, id as string);
+  const { subject, content, isAlarm, alarmTime, color, startDate, startTime, endDate, endTime } =
+    scheduleData;
+
+  const getAlarmOption = (alarmTime: number, isAlarm: boolean) => {
+    switch (alarmTime) {
+      case 0:
+        return isAlarm ? ALARM_OPTIONS.ON_TIME : ALARM_OPTIONS.NONE;
+      case 600:
+        return ALARM_OPTIONS.TEN_MINUTES;
+      case 1800:
+        return ALARM_OPTIONS.THIRTY_MINUTES;
+    }
+  };
+
+  const alarmOption = getAlarmOption(alarmTime, isAlarm);
+
+  const onEdit = async (data: ScheduleFormDataModel) => {
+    const newData = { ...scheduleData, ...data };
+
+    await dispatch(fetchEditSchedule(newData)).then((state) => {
+      if (state.meta.requestStatus === 'fulfilled') {
+        toastTrigger('일정이 수정되었습니다.');
+        navigate(PATH.SCHEDULE);
+      }
+    });
   };
 
   return (
     <>
       <Header />
-      <ScheduleForm onSubmit={onEdit} />
+      <ScheduleForm
+        initTitleValue={subject}
+        initContentValue={content}
+        initEnableAllDay={startTime === '00:00' && endTime === '23:59'}
+        initSelectedAlarmOption={alarmOption}
+        initSelectedColor={color as ColorsType}
+        initStartDate={new Date(startDate)}
+        initEndDate={new Date(endDate)}
+        initStartTime={startTime}
+        initEndTime={endTime}
+        submitButtonText='일정 수정하기'
+        onSubmit={onEdit}
+      />
     </>
   );
 };

--- a/src/store/reducer/scheduleSlice.ts
+++ b/src/store/reducer/scheduleSlice.ts
@@ -1,11 +1,11 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { collection, deleteDoc, doc, getDocs, query, where } from 'firebase/firestore';
 
-import { auth, db } from '@/api';
-import { addSchedule } from '@/api/schedule';
+import { db } from '@/api';
+import { addSchedule, editSchedule } from '@/api/schedule';
 import { status } from '@/types/api';
 import { ScheduleFormDataModel, ScheduleModel } from '@/types/schedule';
-import { checkAuth, getUID } from '@/utils/auth';
+import { getUID } from '@/utils/auth';
 
 export interface ScheduleState {
   schedule: ScheduleModel[];
@@ -62,6 +62,17 @@ export const scheduleSlice = createSlice({
       .addCase(fetchAddSchedule.rejected, (state, action) => {
         state.status = 'failed';
         state.error = action.error.message || '일정을 추가할 수 없습니다.';
+      })
+      .addCase(fetchEditSchedule.pending, (state) => {
+        state.status = 'loading';
+      })
+      .addCase(fetchEditSchedule.fulfilled, (state) => {
+        state.status = 'succeeded';
+        state.isFetched = false;
+      })
+      .addCase(fetchEditSchedule.rejected, (state, action) => {
+        state.status = 'failed';
+        state.error = action.error.message || '일정을 수정할 수 없습니다.';
       });
   },
 });
@@ -76,6 +87,7 @@ export const fetchSchedule = createAsyncThunk('schedule/fetchSchedule', async ()
       (doc) =>
         ({
           ...doc.data(),
+          docId: doc.id,
         }) as ScheduleModel
     );
 
@@ -103,7 +115,18 @@ export const fetchAddSchedule = createAsyncThunk(
     try {
       return await addSchedule(data);
     } catch (error) {
-      return rejectWithValue('일정을 삭제할 수 없습니다.');
+      return rejectWithValue('일정을 추가할 수 없습니다.');
+    }
+  }
+);
+
+export const fetchEditSchedule = createAsyncThunk(
+  'schedule/fetchEditSchedule',
+  async (data: ScheduleModel, { rejectWithValue }) => {
+    try {
+      return await editSchedule(data);
+    } catch (error) {
+      return rejectWithValue('일정을 수정할 수 없습니다.');
     }
   }
 );

--- a/src/types/schedule.d.ts
+++ b/src/types/schedule.d.ts
@@ -13,4 +13,5 @@ export interface ScheduleFormDataModel {
 export interface ScheduleModel extends ScheduleFormDataModel {
   id: number;
   userNo: string;
+  docId?: string;
 }

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -14,3 +14,12 @@ export const getEventList = (schedules: ScheduleModel[]): EventModel[] =>
       color: scheduleColors[color],
     };
   });
+
+export const getScheduleData = (schedules: ScheduleModel[], id: string): ScheduleModel => {
+  const schedule = schedules.find((schedule) => schedule.id === +id);
+
+  if (!schedule) {
+    throw new Error(`${id}번 일정을 찾을 수 없습니다.`);
+  }
+  return schedule;
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

일정 수정 기능 구현했습니다!
혜진님 작업과 충돌이 생길까봐 수정 버튼을 클릭하면 edit 페이지로 이동하는 부분은 작업을 안했고,
상세 페이지에 들어가서 url의 `detail`을 `edit`으로 변경하면 해당 일정의 edit 페이지를 확인하실 수 있습니다

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 일정 수정 기능 추가
- edit path를 `edit/:id`로 변경
- 기존 일정 데이터를 가져올 때 doc.id가 없어서 업데이트할 일정 데이터를 특정하기 어려워 doc.id를 추가했습니다!

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
